### PR TITLE
Update CI/CD pipeline to deploy to WP HH/HX cluster

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
-
+# master -> ensemblgenomes.org -> WP HH/HX (eg-static)
+# all other branches -> review apps -> WP HX (ensembl-dev)
 
 stages:
   - build_static
@@ -26,8 +27,6 @@ Build-Static:
     name: static_assets
     paths:
     - dist/
-  only:
-    - master
 
 Docker-Image:
   stage: build_docker
@@ -41,15 +40,13 @@ Docker-Image:
     - docker push ${EG_DOCKER_IMAGE}
     - docker rmi ${EG_DOCKER_IMAGE}
     - docker logout $CI_REGISTRY
-  only:
-    - master
 
 Deploy:
   extends: .deploy
   # Deploy to dev env so that we can have review.ensembl.org URL
   environment:
     name : wp-hx-dev 
-  only:
+  except:
     - master
 
 # Deploy to WP-HH cluster (Primary)
@@ -60,7 +57,7 @@ Deploy:WP-HH:
   only:
     - master
 
-# Deploy to WP-HX cluster (Fallbak)
+# Deploy to WP-HX cluster (Fallback)
 Deploy:WP-HX:
   extends: .deploy
   environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,13 @@ stages:
 variables:
   EG_DOCKER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
 
+.deploy:
+  stage: deploy
+  image: dockerhub.ebi.ac.uk/kamal/deploy-tools:0.1
+  script:
+    - sed -i "s#<DOCKER_IMAGE>#${EG_DOCKER_IMAGE}#g" ensemblgenomes_deployment.yaml
+    - kubectl apply -f ensemblgenomes_deployment.yaml
+
 Build-Static:
   stage: build_static
   image: node:lts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,6 @@ Deploy:WP-HH:
 # Deploy to WP-HX cluster (Fallbak)
 Deploy:WP-HX:
   extends: .deploy
-  # Deploy to dev env so that we can have review.ensembl.org URL
   environment:
     name : wp-hx-live
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,13 +45,26 @@ Docker-Image:
     - master
 
 Deploy:
-  stage: deploy
-  image: dockerhub.ebi.ac.uk/kamal/deploy-tools:0.1
-  script:
-    - sed -i "s#<DOCKER_IMAGE>#${EG_DOCKER_IMAGE}#g" ensemblgenomes_deployment.yaml
-    - kubectl apply -f ensemblgenomes_deployment.yaml
+  extends: .deploy
   # Deploy to dev env so that we can have review.ensembl.org URL
   environment:
     name : wp-hx-dev 
+  only:
+    - master
+
+# Deploy to WP-HH cluster (Primary)
+Deploy:WP-HH:
+  extends: .deploy
+  environment:
+    name : wp-hh-live
+  only:
+    - master
+
+# Deploy to WP-HX cluster (Fallbak)
+Deploy:WP-HX:
+  extends: .deploy
+  # Deploy to dev env so that we can have review.ensembl.org URL
+  environment:
+    name : wp-hx-live
   only:
     - master


### PR DESCRIPTION
- Use deploy template to deploy to various environment
- Deploy ensemblgenomes.org to WP HH/HX cluster in eg-static namespace 

